### PR TITLE
Fix auto message when exception name has consecutive capital letters

### DIFF
--- a/src/BaseException.php
+++ b/src/BaseException.php
@@ -28,14 +28,15 @@ abstract class BaseException extends \Exception
 
     private function generateMessage(string $message): string
     {
-        $generated = str_replace('Exception', '', $message);
-        $generated = preg_replace_callback(
-            '/[A-Z]/',
-            function ($match) {
-                return ' ' . strtolower($match[0]);
-            },
-            $generated
+        $words = preg_split(
+            '/(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/',
+            str_replace('Exception', '', $message)
         );
+
+        $generated = '';
+        foreach ($words as $word) {
+            $generated .= ' ' . strtolower($word);
+        }
 
         return ucfirst(trim($generated));
     }

--- a/tests/BaseExceptionTest.php
+++ b/tests/BaseExceptionTest.php
@@ -16,6 +16,13 @@ class BaseExceptionTest extends TestCase
         throw new SomethingNotFoundException();
     }
 
+    public function testEmptyMessageWithConsecutiveCapitalLetters()
+    {
+        $this->expectExceptionMessage('Consecutive capital letters');
+
+        throw new ConsecutiveCAPITALLettersException();
+    }
+
     public function testEmptyMessageWithValue()
     {
         $this->expectExceptionMessage('Something not found: 404');

--- a/tests/ConsecutiveCAPITALLettersException.php
+++ b/tests/ConsecutiveCAPITALLettersException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Adlacruzes\Exceptions\Tests;
+
+use Adlacruzes\Exceptions\BaseException;
+
+class ConsecutiveCAPITALLettersException extends BaseException
+{
+}


### PR DESCRIPTION
Fix auto message when exception name has consecutive capital letters